### PR TITLE
Update Backend Image v1.0.9

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
 images:
 - name: todoapp-backend
   newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-backend
-  newTag: 1.0.9
+  newTag: v1.0.9
 - name: todoapp-frontend
   newName: asia-northeast1-docker.pkg.dev/phu-le-it/todoapp-repository/todoapp-frontend
   newTag: 1.0.4


### PR DESCRIPTION
Update Backend Container Image
- New Image Tag: v1.0.9
- Build: [Click Here][1]

[1]: https://github.com/p-le/devops-todoapp-backend/actions/runs/1896312231